### PR TITLE
increase max JSON depth for pruned FeatureData output file

### DIFF
--- a/RemoveSkippedScenarios.ps1
+++ b/RemoveSkippedScenarios.ps1
@@ -261,4 +261,4 @@ PruneFeatureData $FeatureData $TestExecutionHashes
 # ----------------------------------------------------------------------------------------------------
 
 Write-Host "Saving the pruned Feature Data to '$PrunedFeatureDataPath'"
-$FeatureData | ConvertTo-Json -Depth 20 | Out-File "$PrunedFeatureDataPath"
+$FeatureData | ConvertTo-Json -Depth 100 | Out-File "$PrunedFeatureDataPath"


### PR DESCRIPTION
Fixing issue #4 

Increasing the hardcoded max JSON depth value.